### PR TITLE
fix: NemaGFX requires word-aligned buffers

### DIFF
--- a/Core/Inc/lv_conf.h
+++ b/Core/Inc/lv_conf.h
@@ -624,13 +624,14 @@
 /** Define a custom attribute for `lv_display_sync_ready` function */
 #define LV_ATTRIBUTE_SYNC_READY
 
-/** Align VG_LITE buffers on this number of bytes.
- *  @note  vglite_src_buf_aligned() uses this value to validate alignment of passed buffer pointers. */
-#define LV_ATTRIBUTE_MEM_ALIGN_SIZE 1
+/** Align memory buffers on this number of bytes.
+ *  @note  vglite_src_buf_aligned() uses this value to validate alignment of passed buffer pointers. 
+ *  @note  nemagfx requires image buffers to be word-aligned (at least 4 bytes) */
+#define LV_ATTRIBUTE_MEM_ALIGN_SIZE 4
 
 /** Will be added where memory needs to be aligned (with -Os data might not be aligned to boundary by default).
  *  E.g. __attribute__((aligned(4)))*/
-#define LV_ATTRIBUTE_MEM_ALIGN
+#define LV_ATTRIBUTE_MEM_ALIGN __attribute__((aligned(LV_ATTRIBUTE_MEM_ALIGN_SIZE)))
 
 /** Attribute to mark large constant arrays, for example for font bitmaps */
 #define LV_ATTRIBUTE_LARGE_CONST


### PR DESCRIPTION
NemaGFX buffers (src and dst) must be word-aligned.

This commit introduces a two-line change, to ensure all LVGL memory buffers (including (static) image buffers) are word-aligned.
Otherwise, you might get funny colors if your images do not start on word-boundary.

Ref: https://github.com/lvgl/lvgl/issues/9975

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align all LVGL buffers to 4 bytes to satisfy NemaGFX and prevent color glitches with misaligned images. Sets `LV_ATTRIBUTE_MEM_ALIGN_SIZE` to 4 and defines `LV_ATTRIBUTE_MEM_ALIGN` as `__attribute__((aligned(LV_ATTRIBUTE_MEM_ALIGN_SIZE)))` so image and display buffers are word-aligned.

<sup>Written for commit 59d37c2f38d3da40d141448904529d286a2bccd6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

